### PR TITLE
Remove selection shade on color application

### DIFF
--- a/src/components/RoomVisualizer/RoomVisualizer.js
+++ b/src/components/RoomVisualizer/RoomVisualizer.js
@@ -377,6 +377,10 @@ const RoomVisualizer = () => {
         [selectedSurface]: color
       }
     }));
+    // Deselect surface after applying color to remove selection shade
+    if (selectedSurface) {
+      setSelectedSurface(null);
+    }
   };
 
   // Remove a paint colour from the current palette shortlist

--- a/src/components/RoomVisualizer/components/Visualizer.js
+++ b/src/components/RoomVisualizer/components/Visualizer.js
@@ -47,7 +47,7 @@ const Visualizer = ({
               if (!isSelected && !surfaceColor) return null;
 
               const styleObj = {
-                backgroundColor: surfaceColor ? surfaceColor : 'rgba(0,0,0,0.001)', // nearly transparent if no colour, just for shape
+                backgroundColor: surfaceColor ? surfaceColor : (isSelected ? 'rgba(0,0,0,0.25)' : 'rgba(0,0,0,0.001)'),
                 maskImage: maskLoaded ? `url(${surface.mask})` : 'none',
                 WebkitMaskImage: maskLoaded ? `url(${surface.mask})` : 'none',
                 maskSize: 'cover',
@@ -64,14 +64,17 @@ const Visualizer = ({
                 transition: 'opacity 0.2s ease',
               };
 
-              if (isSelected) {
+              // Only show selection glow when there's no paint applied
+              if (isSelected && !surfaceColor) {
                 styleObj.filter = 'drop-shadow(0 0 3px rgba(255,0,0,0.9)) drop-shadow(0 0 3px rgba(255,0,0,0.9))';
               }
+
+              const overlayOpacityClass = surfaceColor ? 'opacity-100' : (isSelected ? 'opacity-100' : 'opacity-80');
 
               return (
                 <div
                   key={surface.id}
-                  className={`absolute inset-0 w-full h-full rounded-2xl lg:rounded-3xl ${isSelected ? 'opacity-100' : 'opacity-80'}`}
+                  className={`absolute inset-0 w-full h-full rounded-2xl lg:rounded-3xl ${overlayOpacityClass}`}
                   style={styleObj}
                 />
               );

--- a/src/components/RoomVisualizer/components/Visualizer.js
+++ b/src/components/RoomVisualizer/components/Visualizer.js
@@ -64,11 +64,6 @@ const Visualizer = ({
                 transition: 'opacity 0.2s ease',
               };
 
-              // Only show selection glow when there's no paint applied
-              if (isSelected && !surfaceColor) {
-                styleObj.filter = 'drop-shadow(0 0 3px rgba(255,0,0,0.9)) drop-shadow(0 0 3px rgba(255,0,0,0.9))';
-              }
-
               const overlayOpacityClass = surfaceColor ? 'opacity-100' : (isSelected ? 'opacity-100' : 'opacity-80');
 
               return (


### PR DESCRIPTION
Remove selection shade and glow when a wall is painted to show only the applied color.

---
<a href="https://cursor.com/background-agent?bcId=bc-37159f29-5379-4d89-8c47-3f86490d743d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37159f29-5379-4d89-8c47-3f86490d743d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

