### PR TITLE
Make heart graphic clickable anywhere

### DIFF
--- a/src/components/CitySelector/CitySelector.js
+++ b/src/components/CitySelector/CitySelector.js
@@ -333,6 +333,33 @@ const CitySelector = () => {
               </div>
             </animated.div>
 
+            {/* Clickable overlay covering the heart area */}
+            <button
+              type="button"
+              aria-label="Explore selected location"
+              onClick={handleCityClick}
+              className="absolute"
+              style={{
+                width: '70vw',
+                height: '70vw',
+                maxWidth: '1400px',
+                maxHeight: '1400px',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                WebkitMask: 'url(/SelectionHeartMask.svg) no-repeat center',
+                mask: 'url(/SelectionHeartMask.svg) no-repeat center',
+                WebkitMaskSize: 'contain',
+                maskSize: 'contain',
+                WebkitMaskPosition: 'center',
+                maskPosition: 'center',
+                backgroundColor: 'rgba(0,0,0,0.01)',
+                cursor: 'pointer',
+                zIndex: 50,
+                border: 'none',
+                padding: 0,
+              }}
+            />
             {/* Carousel container */}
             <div
               className="relative w-full flex items-center overflow-hidden"


### PR DESCRIPTION
Make the entire heart graphic in `CitySelector` clickable for navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-b860a462-7277-41a0-bff0-9c3ad888022d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b860a462-7277-41a0-bff0-9c3ad888022d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

