### PR TITLE
Enforce landscape mode with overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,9 +17,65 @@
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap"
       rel="stylesheet"
     />
+    <style>
+      /* Portrait-only blocking overlay */
+      #orientation-overlay {
+        position: fixed;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        display: none;
+        z-index: 2147483647;
+        background: #0b0b0f;
+        color: #ffffff;
+        text-align: center;
+        padding: 24px;
+      }
+      #orientation-overlay .inner {
+        max-width: 720px;
+        margin: 0 auto;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      #orientation-overlay h1 {
+        font: 700 24px/1.3 "Open Sans", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans";
+        margin: 0 0 12px;
+      }
+      #orientation-overlay p {
+        font: 400 16px/1.6 "Open Sans", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans";
+        opacity: 0.9;
+        margin: 0;
+      }
+      #orientation-overlay .icon {
+        width: 72px;
+        height: 72px;
+        margin-bottom: 16px;
+        opacity: 0.9;
+      }
+      @media (orientation: portrait) {
+        #orientation-overlay { display: block; }
+      }
+      @media (orientation: landscape) {
+        #orientation-overlay { display: none; }
+      }
+    </style>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="orientation-overlay" aria-hidden="true">
+      <div class="inner">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+          <path d="M7 7h10a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M12 3v3M4.6 5.5l2.1 2.1M19.4 5.5l-2.1 2.1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+        <h1>Please rotate your device</h1>
+        <p>This experience is optimized for landscape orientation. Rotate to landscape to continue.</p>
+      </div>
+    </div>
   </body>
 </html> 


### PR DESCRIPTION
Add a CSS-only overlay to block app usage in portrait mode, enforcing landscape orientation.

---
<a href="https://cursor.com/background-agent?bcId=bc-3334e31f-9abf-4d13-9c08-1b20f2c604ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3334e31f-9abf-4d13-9c08-1b20f2c604ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

