### PR TITLE
Restrict video skip to button only

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.js
+++ b/src/components/VideoPlayer/VideoPlayer.js
@@ -104,7 +104,6 @@ const VideoPlayer = () => {
         ref={videoRef}
         className="w-full h-full object-cover"
         onEnded={handleVideoEnd}
-        onClick={handleVideoClick}
         onTimeUpdate={handleTimeUpdate}
         muted
         playsInline


### PR DESCRIPTION
Remove click-to-skip behavior from video element to allow skipping only via the dedicated Skip button.

---
<a href="https://cursor.com/background-agent?bcId=bc-15c70bd3-57e1-4c9e-8186-abda46f4d5ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15c70bd3-57e1-4c9e-8186-abda46f4d5ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

