### PR TITLE
Disable carousel drag on heart click and video load

### DIFF
--- a/src/components/CitySelector/CitySelector.js
+++ b/src/components/CitySelector/CitySelector.js
@@ -145,7 +145,7 @@ const CitySelector = () => {
   };
 
   const onPointerDown = (e) => {
-    if (isTransitioning) return;
+    if (isTransitioning || isGlobalLoading) return;
     if (e.pointerType === 'mouse' && e.button !== 0) return; // only primary button
     setIsDragging(true);
     const x = typeof e.clientX === 'number' ? e.clientX : (e.touches && e.touches[0] ? e.touches[0].clientX : 0);
@@ -162,7 +162,7 @@ const CitySelector = () => {
   };
 
   const onPointerMove = (e) => {
-    if (!isDragging) return;
+    if (!isDragging || isGlobalLoading) return;
     const x = typeof e.clientX === 'number' ? e.clientX : (e.touches && e.touches[0] ? e.touches[0].clientX : dragRef.current.lastX);
     const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
     const dx = x - dragRef.current.startX;
@@ -284,6 +284,7 @@ const CitySelector = () => {
   };
 
   const handleCityClick = async () => {
+    if (isGlobalLoading) return;
     const selectedCity = cities[selectedIndex];
     const cityKey = selectedCity.name.toLowerCase();
     setIsGlobalLoading(true);
@@ -535,7 +536,7 @@ const CitySelector = () => {
               {/* Navigation buttons */}
               <button 
                 onClick={handlePrev} 
-                disabled={isTransitioning}
+                disabled={isTransitioning || isGlobalLoading}
                 className="absolute text-white hover:text-white/80 transition z-30 bg-black/30 rounded-full flex items-center justify-center backdrop-blur-sm disabled:opacity-50"
                 style={{ left: `${clampNumber(8, viewportWidth * 0.02, 48)}px`, top: '50%', transform: 'translateY(-50%)', width: `${clampNumber(28, viewportWidth * 0.03, 60)}px`, height: `${clampNumber(28, viewportWidth * 0.03, 60)}px`, fontSize: `${clampNumber(18, viewportWidth * 0.022, 26)}px` }}
               >
@@ -544,7 +545,7 @@ const CitySelector = () => {
               
               <button 
                 onClick={handleNext} 
-                disabled={isTransitioning}
+                disabled={isTransitioning || isGlobalLoading}
                 className="absolute text-white hover:text-white/80 transition z-30 bg-black/30 rounded-full flex items-center justify-center backdrop-blur-sm disabled:opacity-50"
                 style={{ right: `${clampNumber(8, viewportWidth * 0.02, 48)}px`, top: '50%', transform: 'translateY(-50%)', width: `${clampNumber(28, viewportWidth * 0.03, 60)}px`, height: `${clampNumber(28, viewportWidth * 0.03, 60)}px`, fontSize: `${clampNumber(18, viewportWidth * 0.022, 26)}px` }}
               >
@@ -579,11 +580,11 @@ const CitySelector = () => {
                   // Sliding finished (let heart/text sequence control final state)
                   setTimeout(() => setIsTransitioning(false), 0);
                 }}
-                className={`flex h-full ${!instantJump && isTransitioning ? 'transition-transform duration-500 ease-in-out' : ''} ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+                className={`flex h-full ${!instantJump && isTransitioning ? 'transition-transform duration-500 ease-in-out' : ''} ${isGlobalLoading ? 'cursor-wait' : (isDragging ? 'cursor-grabbing' : 'cursor-grab')}`}
                 style={{
                   transform: `translateX(${translateX + dragOffset}px)`,
                   width: `${extendedCities.length * itemWidth}px`,
-                  touchAction: 'pan-y',
+                  touchAction: isGlobalLoading ? 'none' : 'pan-y',
                 }}
               >
                 {extendedCities.map((city, index) => {


### PR DESCRIPTION
Lock carousel dragging and navigation buttons while a hotspot video is loading after a center heart click.

This prevents unintended carousel movement or navigation attempts while the video content is being prepared, improving user experience during loading states.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f37657d-12fa-41a8-91f8-3373169aead4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f37657d-12fa-41a8-91f8-3373169aead4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

