### PR TITLE
Manage protip div visibility and interaction

### DIFF
--- a/src/components/RoomVisualizer/components/Visualizer.js
+++ b/src/components/RoomVisualizer/components/Visualizer.js
@@ -19,6 +19,9 @@ const Visualizer = ({
   onClearAreas,
   onShare
 }) => {
+  // State for Protip visibility
+  const [isProtipExpanded, setIsProtipExpanded] = React.useState(true);
+  
   // Maintain base image aspect ratio on small viewports (landscape mobile)
   // Landscape scaling (mobile) relative to FHD baseline
   const [landscapeScale, setLandscapeScale] = React.useState(1);
@@ -45,6 +48,9 @@ const Visualizer = ({
       window.removeEventListener('orientationchange', updateScale);
     };
   }, []);
+
+  // Determine if Protip should be visible based on instruction
+  const showProtip = !shouldBlinkSelection; // Show on second instruction, hide on first
 
   
   
@@ -343,26 +349,56 @@ const Visualizer = ({
               Share
             </button>
           </div>
-          {/* Pro tip row below instruction and share */}
-          <div className="w-full px-6 mt-0 lg:mt-1">
-            <div className="w-full max-w-[1100px] mx-auto bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 lg:px-5 lg:py-3 shadow-[0_1px_0_rgba(0,0,0,0.04)]">
-              <div className="flex items-start gap-3">
-                <span className="inline-flex items-center justify-center rounded-full bg-amber-100 p-[clamp(6px,1vmin,10px)] shrink-0">
-                  <img
-                    src="/bulb-creative-idea-svgrepo-com.svg"
-                    alt="Pro tip"
-                    className="w-[clamp(18px,1.6vmin,24px)] h-[clamp(18px,1.6vmin,24px)] object-contain block"
-                    draggable={false}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                </span>
-                <p className="m-0 text-[#575454] font-brand italic leading-snug text-[clamp(10px,1.9vmin,16px)]">
-                  For a soft and subtle look, stick with shades A–D. For a bold and vibrant look, start with E or F, then mix in shades from A to D to balance it out.
-                </p>
+          {/* Pro tip row below instruction and share - only show on second instruction */}
+          {showProtip && (
+            <div className="w-full px-6 mt-0 lg:mt-1">
+              <div className="w-full max-w-[1100px] mx-auto bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 lg:px-5 lg:py-3 shadow-[0_1px_0_rgba(0,0,0,0.04)]">
+                <div className="flex items-start gap-3">
+                  <span 
+                    className="inline-flex items-center justify-center rounded-full bg-amber-100 p-[clamp(6px,1vmin,10px)] shrink-0 cursor-pointer"
+                    onClick={() => setIsProtipExpanded(!isProtipExpanded)}
+                    title={isProtipExpanded ? "Collapse tip" : "Expand tip"}
+                  >
+                    <img
+                      src="/bulb-creative-idea-svgrepo-com.svg"
+                      alt="Pro tip"
+                      className="w-[clamp(18px,1.6vmin,24px)] h-[clamp(18px,1.6vmin,24px)] object-contain block"
+                      draggable={false}
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  </span>
+                  {isProtipExpanded && (
+                    <>
+                      <p className="m-0 text-[#575454] font-brand italic leading-snug text-[clamp(10px,1.9vmin,16px)]">
+                        For a soft and subtle look, stick with shades A–D. For a bold and vibrant look, start with E or F, then mix in shades from A to D to balance it out.
+                      </p>
+                      <button
+                        onClick={() => setIsProtipExpanded(false)}
+                        className="ml-auto text-gray-500 hover:text-gray-700 p-1 rounded-full hover:bg-gray-200 transition-colors"
+                        title="Close tip"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <line x1="18" y1="6" x2="6" y2="18"></line>
+                          <line x1="6" y1="6" x2="18" y2="18"></line>
+                        </svg>
+                      </button>
+                    </>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
+          )}
 
           
           


### PR DESCRIPTION
Implement conditional display and collapse/expand functionality for the Protip div.

The Protip is now hidden on the first instruction ("Select the wall you want to paint.") and shown on the second. A cross button allows users to collapse the Protip, showing only its icon, which can then be clicked to re-expand the tip. This improves user guidance and allows for a less cluttered interface when not needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-d21b437d-7bac-4258-bcaf-85ce92c58da0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d21b437d-7bac-4258-bcaf-85ce92c58da0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

