### PR TITLE
Fix blinking outline on colored walls

### DIFF
--- a/src/components/RoomVisualizer/components/Visualizer.js
+++ b/src/components/RoomVisualizer/components/Visualizer.js
@@ -271,8 +271,8 @@ const Visualizer = ({
                 );
               }
 
-              // Pre-selection blink outline on top (applies to all surfaces)
-              if (shouldBlinkSelection) {
+              // Pre-selection blink outline on top (applies only to surfaces without color)
+              if (shouldBlinkSelection && !surfaceColor) {
                 overlays.push(
                   <img
                     key={`blink-${surface.id}`}


### PR DESCRIPTION
Prevent blinking outline animation on colored walls to improve user guidance.

The original behavior caused confusion as walls with a pre-applied hotspot color would still blink, suggesting they needed selection. This change ensures that only unpainted walls blink, clearly indicating which surfaces are available for painting.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee7ca968-44ba-4d46-9e27-dd61de2f6957">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee7ca968-44ba-4d46-9e27-dd61de2f6957">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

